### PR TITLE
event_scheduler.py: cancel() throwing an error when empty

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -24,4 +24,4 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-urllib3==1.26.3
+urllib3==1.26.4

--- a/event_scheduler/event_scheduler.py
+++ b/event_scheduler/event_scheduler.py
@@ -257,7 +257,7 @@ class EventScheduler:
             if self._scheduler_status != SchedulerStatus.RUNNING:
                 return -1
             try:
-                if self._queue[0] == event:
+                if self._queue and self._queue[0] == event:
                     self._notify()
                 self._queue.remove(event)
                 heapq.heapify(self._queue)

--- a/tests/unit_tests/event_scheduler_tests.py
+++ b/tests/unit_tests/event_scheduler_tests.py
@@ -256,6 +256,21 @@ class EventSchedulerTests(unittest.TestCase):
         event_scheduler.stop()
         self.assertListEqual(result_list, ['B'])
 
+    def test_cancel_event_after_execution(self):
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
+        event_scheduler.start()
+        result_list = []
+        event = event_scheduler.enter(2, 4, insert_into_list, (),
+                                      {'item':'B', 'list_obj':result_list})
+        TestTimer.advance_time(2.5)
+        # cancelling an already executed event should be a no-op
+        event_scheduler.cancel(event)
+        self.assertListEqual(result_list, ['B'])
+        event_scheduler.stop(True)
+
     def test_cancel_recurring_event(self):
         event_scheduler = EventScheduler(TEST_THREAD,
                                          TestTimer.monotonic,


### PR DESCRIPTION
This PR addresses an issue where an "index out of range" is thrown when trying to cancel an event that has already been executed when the queue is empty.